### PR TITLE
Add support for publishing historical exposedAt timestamp

### DIFF
--- a/sdk/context.py
+++ b/sdk/context.py
@@ -407,8 +407,7 @@ class Context:
                         event.attributes = None
                     event.exposures = exposures
                     event.goals = achievements
-                    if self.historic:
-                        event.historic = True
+                    event.historic = self.historic
 
                     result = Future()
 

--- a/sdk/context_config.py
+++ b/sdk/context_config.py
@@ -11,4 +11,4 @@ class ContextConfig:
     overrides: {} = None
     attributes: {} = None
     units: {} = None
-    historic: bool = True
+    historic: bool = False

--- a/sdk/context_config.py
+++ b/sdk/context_config.py
@@ -11,3 +11,4 @@ class ContextConfig:
     overrides: {} = None
     attributes: {} = None
     units: {} = None
+    historic: bool = True

--- a/sdk/json/publish_event.py
+++ b/sdk/json/publish_event.py
@@ -13,3 +13,4 @@ class PublishEvent:
     exposures: typing.Optional[list[Exposure]] = None
     goals: typing.Optional[list[GoalAchievement]] = None
     attributes: typing.Optional[list[Attribute]] = None
+    historic: typing.Optional[bool] = False

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -1119,3 +1119,19 @@ class ContextTest(unittest.TestCase):
         context.close()
         self.assertEqual(self.event_logger.logger_type, EventType.CLOSE)
         self.assertIsNone(self.event_logger.logger_data)
+
+    def test_assignment_with_historical_exposed_at_timestamp(self):
+        self.set_up()
+        config = ContextConfig()
+        config.units = self.units
+        context = self.create_test_context(config, self.data_future_ready)
+        self.assertEqual(True, context.is_ready())
+        self.assertEqual(False, context.is_failed())
+
+        res = context.get_treatment(
+            "exp_test_historical_timestamp",
+            exposed_at = 1713218400000
+        )
+        exposure = context.exposures[0]
+        self.assertEqual(1713218400000, exposure.exposedAt)
+        context.close()


### PR DESCRIPTION
This PR enables us to generate exposures with historical `exposedAt` timestamp. This is useful for some of our ML A/B testing use cases where we generate batch predictions in advance for all users, but we only know some time hours/days later when each user was exposed to their corresponding prediction. In this scenario we can now:
- use the `peak_treatment` method to check the variant for each user when we generate the predictions in advance
- use the `get_treatment` method some time later to generate the exposure using historical `exposedAt` timestamps.

Changes included in this PR:
- added `historic` attribute to `ContextConfig` and `PublishEvent` classes
- added optional `exposedAt` attribute to `Assignment` class
- updated the `Context.get_treatment` and `Context.get_assignment` methods so that we can optionally pass a historical `exposedAt` timestamp
- updated the `Context.queue_exposure` method so that the historical `exposedAt` timestamp is used if it's value is not `None` (if it is `None` then the existing logic is preserved and the `exposedAt` timestamp will be set to the current time)
- added a unit test `test_assignment_with_historical_exposed_at_timestamp`

I've also tested this change with the script below and verified that exposures with historical timestamp are appearing correctly in the ABSmartly UI
```
import os
from sdk.absmartly_config import ABSmartlyConfig
from sdk.context_config import ContextConfig
from sdk.absmartly import ABSmartly
from sdk.client import Client
from sdk.client_config import ClientConfig
from sdk.default_http_client import DefaultHTTPClient
from sdk.default_http_client_config import DefaultHTTPClientConfig


# Refer to task here regarding this address: https://catawiki.atlassian.net/browse/AB-163
ABSMARTLY_ENDPOINT = "https://catawiki.absmartly.io/v1"
ABSMARTLY_API_KEY = os.getenv("ABSMARTLY_API_KEY")
ENVIRONMENT = "development"
APPLICATION = "ML"
UNITS = {
    "user_id": "1234"
}
ATTRIBUTES = {}
EXPERIMENT_NAME = "test_python_ab"
HISTORIC = True
EXPOSED_AT = 1713330000000

# Create context
client_config = ClientConfig()
client_config.endpoint = ABSMARTLY_ENDPOINT
client_config.api_key = ABSMARTLY_API_KEY
client_config.application = APPLICATION
client_config.environment = ENVIRONMENT
default_client_config = DefaultHTTPClientConfig()
default_client = DefaultHTTPClient(default_client_config)
sdk_config = ABSmartlyConfig()
sdk_config.client = Client(client_config, default_client)
sdk = ABSmartly(sdk_config)
context_config = ContextConfig()
context_config.units = UNITS
context_config.attributes = ATTRIBUTES
context_config.historic = HISTORIC
context = sdk.create_context(context_config)
context.wait_until_ready()

# Get treatment
treatment = context.get_treatment(
    experiment_name=EXPERIMENT_NAME,
    exposed_at=EXPOSED_AT
)
print(treatment)

# Publish context
context.publish()

# Close context
context.close()
```
<img width="1116" alt="image" src="https://github.com/absmartly/python3-sdk/assets/114925484/d73fa91f-6277-4af4-887f-cb4758f5a2f8">
